### PR TITLE
Added support for copying resources and sdc-extras to the image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .gitreview
+.DS_Store
+._.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,15 @@ RUN /sdc-configure.sh && rm /sdc-configure.sh
 ARG SDC_LIBS
 RUN if [ -n "${SDC_LIBS}" ]; then "${SDC_DIST}/bin/streamsets" stagelibs -install="${SDC_LIBS}"; fi
 
+# Copy any local files in the $PROJECT_ROOT/resources dir to the SDC_RESOURCES dir
+COPY --chown=sdc:sdc resources/ ${SDC_RESOURCES}/
+
+# Copy any local "sdc-extras" libs to STREAMSETS_LIBRARIES_EXTRA_DIR
+# Local files should be placed in appropriate stage lib subdirectories.  For example
+# to add a JDBC driver like ojdbc8.jar to the JDBC stage lib, the local file ojdbc8.jar
+# should be at $PROJECT_ROOT/sdc-extras/streamsets-datacollector-jdbc-lib/lib/ojdbc8.jar
+COPY --chown=sdc:sdc sdc-extras/ ${STREAMSETS_LIBRARIES_EXTRA_DIR}/
+
 USER ${SDC_USER}
 EXPOSE 18630
 COPY docker-entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Detailed Usage
     location is /data for $SDC_DATA. You can override this location by passing a different value to the environment
     variable SDC_DATA. Creating a volume for additional stage libraries is described in more detail below.
 *   You can also specify your own explicit port mappings, or arguments to the streamsets command.
+*   Any files or directories placed in the project's "resources" directory will be copied to the image's ${SDC_RESOURCES} directory
+*   Any files or directories placed in the project's "sdc-extras" directory will be copied to the image's ${STREAMSETS_LIBRARIES_EXTRA_DIR}.  See the Dockerfile for details
 
 For example to run with a customized sdc.properties file, a local filsystem path to store pipelines, and statically map
 the default UI port you could use the following:

--- a/resources/README-resources.txt
+++ b/resources/README-resources.txt
@@ -1,0 +1,1 @@
+# All files or subdirectories placed in this directory will be copied to the image's ${SDC_RESOURCES} directory

--- a/sdc-extras/README-sdc-extras.txt
+++ b/sdc-extras/README-sdc-extras.txt
@@ -1,0 +1,4 @@
+# All files and subdirectories placed here will be copies to the image's ${STREAMSETS_LIBRARIES_EXTRA_DIR} directory
+# Files should be placed in appropriate stage lib subdirectories.  For example
+# to add a JDBC driver like ojdbc8.jar to the JDBC stage lib, the local file 
+# should be at $PROJECT_ROOT/sdc-extras/streamsets-datacollector-jdbc-lib/lib/ojdbc8.jar


### PR DESCRIPTION
Added support for copying resources and sdc-extras to the image.  Files and direcrories placed in the project's resources directory will be copied to the images's ${SDC_RESOURCES} directory and files and direcrories placed in the project's sdc-extras directory will be copied to the image's  ${STREAMSETS_LIBRARIES_EXTRA_DIR}