### PR TITLE
Add the ignore-case flag to the set_conf function

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ set_conf() {
     exit 1
   fi
 
-  sed -i 's|^#\?\('"$1"'=\).*|\1'"$2"'|' "${SDC_CONF}/sdc.properties"
+  sed -i 's|^#\?\('"$1"'=\).*|\1'"$2"'|I' "${SDC_CONF}/sdc.properties"
 }
 
 # In some environments such as Marathon $HOST and $PORT0 can be used to


### PR DESCRIPTION
I tried setting an environment variable named `SDC_CONF_PRODUCTION_MAXBATCHSIZE`, which was converted by the script to `production.maxbatchsize`, but the command was not properly replacing the value since the actual real property name is maxBatchSize. Adding this ignore-case flag in the sed command fixed this issue.

I used the following command in my Dockerfile to fix it and thought that sharing this here would be beneficial to others.

```
FROM streamsets/datacollector:3.7.2

RUN sed -i '0,/sed -i/s/\(.*|\)/\1I/' /docker-entrypoint.sh
```